### PR TITLE
Update Github Action for Publishing to Comfy Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,27 @@
-[project]
-name = "ComfyUI_srt2speech"
-description = "This repo need to use with any TTS, it will be automate subtitle.srt for TTS, check it out from my video tutorial here https://youtu.be/pXEbXhNceUo?si=yC2h3SE-cWqKN2bz""
-version = "1.0.1"
-license = {file = "LICENSE"}
+name: Publish to Comfy registry
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "pyproject.toml"
 
-dependencies = ["torch>=2.0.0", "torchaudio>=2.0.0", "inflect", "pydub", "ffmpeg-python"]
+permissions:
+  issues: write
 
-[project.urls]
-Repository = "https://github.com/gordon123/ComfyUI_srt2speech"
-#  Used by Comfy Registry https://comfyregistry.org
-
-[tool.comfy]
-PublisherId = "aiimate24"
-DisplayName = "ComfyUI_srt2speech"
-Icon = ""
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'gordon123' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. This PR updates the Github Action `publish.yml` to ensure latest ComfyUI Community Standard.

## Updates:

1. **Issue Creating Permission**: Ensures that the workflow can open issues to report publishing states or warnings, facilitating better communication and issue tracking.

```diff
+ # auto issue permission, for Comfy CustomNode registry publishing state
+ permissions:
+   issues: write
```

2. **Conditional Execution**: Only runs the publish job in author’s repo, defaults to repo owner, reference issue here: - [Forks problem: add an organisation or owner check to run the action · Issue #2 · Comfy-Org/publish-node-action](https://github.com/Comfy-Org/publish-node-action/issues/2)

```diff
+     if: ${{ github.repository_owner == 'gordon123' }}
```

3. **Versioning**: We use explicity version number after stable release, using a stable release version of the action reduces the
   risk of unexpected behavior from changes in the action's main branch.

```diff
-     uses: Comfy-Org/publish-node-action@~~main~~
+     uses: Comfy-Org/publish-node-action@v1
```

## Learn More

Please message me on Discord at robin or join our [server](https://discord.com/invite/comfyorg) server if you have any questions! For more information, visit the official Comfy-Org blog: [ComfyUI Blog](https://blog.comfy.org/).